### PR TITLE
updates & cleanup

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ In [3]: flightinfo["HALO"]["HALO-0119"]["takeoff"]
 Out[3]: datetime.datetime(2020, 1, 19, 9, 34, 25)
 ```
 
-### obtaining general campaign metadata
-
-```ipython
-In [4]: meta = eurec4a.get_meta()
-
-In [5]: meta["ATR42"]["color"]
-Out[5]: '#f7c96b'
-```
-
 ### accessing public datasets via the intake data catalog
 
 ```ipython

--- a/eurec4a/__init__.py
+++ b/eurec4a/__init__.py
@@ -43,16 +43,6 @@ def get_flight_segments(version="latest"):
 
 
 @lru_cache()
-def get_meta():
-    """
-    Download and parse general campaign metadata.
-    This includes information about platforms, instruments, people, data access etc.
-    """
-    return yaml.load(requests.get("https://eurec4a_staging.pages.gwdg.de/eurec4a_meta/meta.yaml").content,
-                     Loader=yaml.SafeLoader)
-
-
-@lru_cache()
 def get_cids():
     return requests.get("https://raw.githubusercontent.com/eurec4a/ipfs_tools/main/cids.json").json()
 

--- a/eurec4a/__init__.py
+++ b/eurec4a/__init__.py
@@ -11,6 +11,7 @@ SEGMENT_REPO = "eurec4a/flight-phase-separation"
 
 
 class GithubApi:
+    @lru_cache()
     def get(self, endpoint):
         url = "https://api.github.com/" + endpoint
         return requests.get(url,
@@ -22,6 +23,7 @@ class GithubApi:
 github = GithubApi()
 
 
+@lru_cache()
 def get_flight_segments(version="latest"):
     """
     Download and parse flight segmentation information.
@@ -40,6 +42,7 @@ def get_flight_segments(version="latest"):
     return yaml.load(requests.get(all_flights_url).content, Loader=yaml.SafeLoader)
 
 
+@lru_cache()
 def get_meta():
     """
     Download and parse general campaign metadata.

--- a/test/test_metadata_availability.py
+++ b/test/test_metadata_availability.py
@@ -11,11 +11,6 @@ def test_flight_segment_availability_by_version():
     assert "HALO" in segments
 
 
-def test_meta_availability():
-    meta = eurec4a.get_meta()
-    assert "HALO" in meta
-
-
 def test_inake_catalog_availability():
     cat = eurec4a.get_intake_catalog()
     assert "barbados" in cat


### PR DESCRIPTION
This PR does a few updates to go with time:

* cache more things: adds `lru_cache` to more functions such that we don't hit rate limits as quickly as we do now,
* remove Python 3.6 support and add Python 3.11 support in testing
* remove `get_meta()`. It's seldomly used and currently broken.